### PR TITLE
fix: Fit compatibility of cuda 9.0 and pytorch 0.4.1

### DIFF
--- a/faster_rcnn/faster_rcnn.py
+++ b/faster_rcnn/faster_rcnn.py
@@ -97,7 +97,7 @@ class RPN(nn.Module):
         rpn_bbox_targets = torch.mul(rpn_bbox_targets, rpn_bbox_inside_weights)
         rpn_bbox_pred = torch.mul(rpn_bbox_pred, rpn_bbox_inside_weights)
 
-        rpn_loss_box = F.smooth_l1_loss(rpn_bbox_pred, rpn_bbox_targets, size_average=False) / (fg_cnt + 1e-4)
+        rpn_loss_box = F.smooth_l1_loss(rpn_bbox_pred, rpn_bbox_targets, size_average=False) / (float(fg_cnt) + 1e-4)
 
         return rpn_cross_entropy, rpn_loss_box
 
@@ -259,7 +259,7 @@ class FasterRCNN(nn.Module):
         bbox_targets = torch.mul(bbox_targets, bbox_inside_weights)
         bbox_pred = torch.mul(bbox_pred, bbox_inside_weights)
 
-        loss_box = F.smooth_l1_loss(bbox_pred, bbox_targets, size_average=False) / (fg_cnt + 1e-4)
+        loss_box = F.smooth_l1_loss(bbox_pred, bbox_targets, size_average=False) / (float(fg_cnt) + 1e-4)
 
         return cross_entropy, loss_box
 

--- a/faster_rcnn/network.py
+++ b/faster_rcnn/network.py
@@ -115,7 +115,7 @@ def clip_gradient(model, clip_norm):
             totalnorm += modulenorm ** 2
     totalnorm = np.sqrt(totalnorm)
 
-    norm = clip_norm / max(totalnorm, clip_norm)
+    norm = clip_norm / max(totalnorm, clip_norm).cuda()
     for p in model.parameters():
         if p.requires_grad:
             p.grad.mul_(norm)

--- a/train.py
+++ b/train.py
@@ -149,8 +149,8 @@ for step in range(start_step, end_step+1):
         if _DEBUG:
             log_print('\tTP: %.2f%%, TF: %.2f%%, fg/bg=(%d/%d)' % (tp/fg*100., tf/bg*100., fg/step_cnt, bg/step_cnt))
             log_print('\trpn_cls: %.4f, rpn_box: %.4f, rcnn_cls: %.4f, rcnn_box: %.4f' % (
-                net.rpn.cross_entropy.data.cpu().numpy()[0], net.rpn.loss_box.data.cpu().numpy()[0],
-                net.cross_entropy.data.cpu().numpy()[0], net.loss_box.data.cpu().numpy()[0])
+                net.rpn.cross_entropy.data.cpu().numpy(), net.rpn.loss_box.data.cpu().numpy(),
+                net.cross_entropy.data.cpu().numpy(), net.loss_box.data.cpu().numpy())
             )
         re_cnt = True
 


### PR DESCRIPTION
- issue: #71 
- cuda 9.0
- pytorch 0.4.1
- test code
```bash
$ CUDA_VISIBLE_DEVICES=0,1,2,3 python train.py
```